### PR TITLE
Fix: passing heredoc's user input with pipes and other commands, & EOF handling in heredocs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SRC_EXPANSION = expansion
 
 # Compiler & flags
 CC = cc
-CFLAGS = -Wall -Werror -Wextra -g3 -fsanitize=address
+CFLAGS = -Wall -Werror -Wextra -g3 #-fsanitize=address
 RM = rm -rf
 
 # Source files

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ SRC_EXPANSION = expansion
 
 # Compiler & flags
 CC = cc
-CFLAGS = -Wall -Werror -Wextra -g3 #-fsanitize=address
+CFLAGS = -Wall -Werror -Wextra -g3 -fsanitize=address
 RM = rm -rf
 
 # Source files

--- a/include/execution.h
+++ b/include/execution.h
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 18:40:52 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 13:45:31 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:39:07 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -51,6 +51,7 @@ typedef struct s_process
 	bool	heredoc_exists;
 	bool	pipe_flag;
 	int		heredoc_fd;
+	bool	dup_heredoc;
 }	t_process;
 
 // typedef struct s_list

--- a/include/execution.h
+++ b/include/execution.h
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 18:40:52 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 15:39:07 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 09:53:09 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -52,6 +52,7 @@ typedef struct s_process
 	bool	pipe_flag;
 	int		heredoc_fd;
 	bool	dup_heredoc;
+	bool	reset_cursor_hd;
 }	t_process;
 
 // typedef struct s_list

--- a/include/execution.h
+++ b/include/execution.h
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 18:40:52 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 09:53:09 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:35:34 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,10 +48,8 @@ typedef struct s_process
 	char	**limiters;
 	int		limiter_index;
 	int		total_hd;
-	bool	heredoc_exists;
 	bool	pipe_flag;
 	int		heredoc_fd;
-	bool	dup_heredoc;
 	bool	reset_cursor_hd;
 }	t_process;
 

--- a/src/execution/exec/pipe/exec_pipe.c
+++ b/src/execution/exec/pipe/exec_pipe.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:08:31 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 11:33:09 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:35:25 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,7 +28,6 @@ void	exec_pipe(t_ast *ast, t_exc *exc)
 	pid_t	right_pid;
 
 	signal(SIGINT, SIG_IGN);
-	signal(EOF, SIG_IGN);
 	exc->process->pipe_flag = true;
 	if (pipe(fd) == -1)
 	{
@@ -51,17 +50,6 @@ void	exec_pipe(t_ast *ast, t_exc *exc)
 //put exit(0) at the end in case its a builtin or ast's NULL
 static void	child_process_left(t_ast *ast, t_exc *exc, int fd[2])
 {
-// 	if (exc->process->infile != -1)
-// 	{
-// 		if (exc->process->infile == exc->process->heredoc_fd)
-// 			fprintf(stderr, "heredoc_fd bring dup2 !!\n");
-// 		dup2(exc->process->infile, STDIN_FILENO);
-// 		close(exc->process->infile);
-// 		if (exc->process->heredoc_fd != -1 && \
-// exc->process->infile != exc->process->heredoc_fd)
-// 			close(exc->process->heredoc_fd);
-// 	}
-
 	close(fd[READ]);
 	dup2(fd[WRITE], STDOUT_FILENO);
 	close(fd[WRITE]);

--- a/src/execution/exec/pipe/exec_pipe.c
+++ b/src/execution/exec/pipe/exec_pipe.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:08:31 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 17:34:15 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 11:33:09 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -28,6 +28,7 @@ void	exec_pipe(t_ast *ast, t_exc *exc)
 	pid_t	right_pid;
 
 	signal(SIGINT, SIG_IGN);
+	signal(EOF, SIG_IGN);
 	exc->process->pipe_flag = true;
 	if (pipe(fd) == -1)
 	{
@@ -50,18 +51,17 @@ void	exec_pipe(t_ast *ast, t_exc *exc)
 //put exit(0) at the end in case its a builtin or ast's NULL
 static void	child_process_left(t_ast *ast, t_exc *exc, int fd[2])
 {
-// 	if (exc->process->infile != -1 && exc->process->dup_heredoc == false)
+// 	if (exc->process->infile != -1)
 // 	{
-// 		// if (exc->process->infile == exc->process->heredoc_fd)
-// 			// fprintf(stderr, "heredoc_fd bring dup2 !!\n");
+// 		if (exc->process->infile == exc->process->heredoc_fd)
+// 			fprintf(stderr, "heredoc_fd bring dup2 !!\n");
 // 		dup2(exc->process->infile, STDIN_FILENO);
 // 		close(exc->process->infile);
 // 		if (exc->process->heredoc_fd != -1 && \
 // exc->process->infile != exc->process->heredoc_fd)
 // 			close(exc->process->heredoc_fd);
-// 		exc->process->dup_heredoc = true;
 // 	}
-//
+
 	close(fd[READ]);
 	dup2(fd[WRITE], STDOUT_FILENO);
 	close(fd[WRITE]);

--- a/src/execution/exec/pipe/exec_pipe.c
+++ b/src/execution/exec/pipe/exec_pipe.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:08:31 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/21 17:02:59 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 17:34:15 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,18 @@ void	exec_pipe(t_ast *ast, t_exc *exc)
 //put exit(0) at the end in case its a builtin or ast's NULL
 static void	child_process_left(t_ast *ast, t_exc *exc, int fd[2])
 {
+// 	if (exc->process->infile != -1 && exc->process->dup_heredoc == false)
+// 	{
+// 		// if (exc->process->infile == exc->process->heredoc_fd)
+// 			// fprintf(stderr, "heredoc_fd bring dup2 !!\n");
+// 		dup2(exc->process->infile, STDIN_FILENO);
+// 		close(exc->process->infile);
+// 		if (exc->process->heredoc_fd != -1 && \
+// exc->process->infile != exc->process->heredoc_fd)
+// 			close(exc->process->heredoc_fd);
+// 		exc->process->dup_heredoc = true;
+// 	}
+//
 	close(fd[READ]);
 	dup2(fd[WRITE], STDOUT_FILENO);
 	close(fd[WRITE]);

--- a/src/execution/exec/redirection/combine_all_heredoc.c
+++ b/src/execution/exec/redirection/combine_all_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/02 21:00:03 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 09:50:19 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:31:27 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -75,7 +75,6 @@ exc->process->total_hd, exc->process);
 	{
 		write(exc->process->heredoc_fd, line, ft_strlen(line));
 		write(exc->process->heredoc_fd, "\n", 1);
-		// fprintf(stderr, "writing user input of heredoc\n");
 		free(line);
 		line = readline("\033[0;34m> \033[0m");
 	}
@@ -98,7 +97,7 @@ int total_hd, t_process *process)
 			break ;
 		curr_limiter = is_limiter(process->limiters[process->limiter_index], \
 line);
-		if (curr_limiter == true)
+		if (curr_limiter == true || !line)
 			process->limiter_index++;
 		free(line);
 		line = readline("\033[0;34m> \033[0m");

--- a/src/execution/exec/redirection/combine_all_heredoc.c
+++ b/src/execution/exec/redirection/combine_all_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/02 21:00:03 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 08:53:21 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,10 +54,10 @@ O_RDWR | O_CREAT | O_TRUNC, 0644);
 		perror("Heredoc's fork failed");
 	if (pid == 0)
 		start_heredoc(exc);
-	close(exc->process->heredoc_fd);
 	waitpid(pid, &exit_status, 0);
 	if (WIFEXITED(exit_status) != 0)
 		exc->exit_code = WEXITSTATUS(exit_status);
+	close(exc->process->heredoc_fd);
 	exc->process->heredoc_fd = reset_cursor_heredocfd(exc);
 	exc->process->infile = exc->process->heredoc_fd;
 }
@@ -77,6 +77,7 @@ exc->process->total_hd, exc->process);
 	{
 		write(exc->process->heredoc_fd, line, ft_strlen(line));
 		write(exc->process->heredoc_fd, "\n", 1);
+		// fprintf(stderr, "writing user input of heredoc\n");
 		free(line);
 		line = readline("\033[0;34m> \033[0m");
 	}

--- a/src/execution/exec/redirection/combine_all_heredoc.c
+++ b/src/execution/exec/redirection/combine_all_heredoc.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/02 21:00:03 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 09:50:19 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -54,12 +54,10 @@ O_RDWR | O_CREAT | O_TRUNC, 0644);
 		perror("Heredoc's fork failed");
 	if (pid == 0)
 		start_heredoc(exc);
+	close(exc->process->heredoc_fd);
 	waitpid(pid, &exit_status, 0);
 	if (WIFEXITED(exit_status) != 0)
 		exc->exit_code = WEXITSTATUS(exit_status);
-	close(exc->process->heredoc_fd);
-	exc->process->heredoc_fd = reset_cursor_heredocfd(exc);
-	exc->process->infile = exc->process->heredoc_fd;
 }
 
 static void	start_heredoc(t_exc *exc)

--- a/src/execution/exec/redirection/rd_others.c
+++ b/src/execution/exec/redirection/rd_others.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/03 09:16:04 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 09:01:27 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 11:01:15 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -72,8 +72,13 @@ void	rd_in(t_ast *ast, t_exc *exc)
 
 void	rd_heredoc(t_ast *ast, t_exc *exc)
 {
-	if (exc->process->infile != -1)
-		if (exc->process->infile != exc->process->heredoc_fd)
+	if (exc->process->reset_cursor_hd == false)
+	{
+	exc->process->heredoc_fd = reset_cursor_heredocfd(exc);
+		exc->process->reset_cursor_hd = true;
+	}
+	if (exc->process->infile != -1 && \
+exc->process->infile != exc->process->heredoc_fd)
 			close(exc->process->infile);
 	exc->process->infile = exc->process->heredoc_fd;
 	execution(ast->left, exc);
@@ -89,5 +94,6 @@ int	reset_cursor_heredocfd(t_exc *exc)
 		exc->exit_code = PERMISSION_DENIED;
 		return (-1);
 	}
+	fprintf(stderr, "FD OPEN: %d\n", exc->process->heredoc_fd);
 	return (exc->process->heredoc_fd);
 }

--- a/src/execution/exec/redirection/rd_others.c
+++ b/src/execution/exec/redirection/rd_others.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/06/03 09:16:04 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 11:01:15 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:09:24 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -74,12 +74,12 @@ void	rd_heredoc(t_ast *ast, t_exc *exc)
 {
 	if (exc->process->reset_cursor_hd == false)
 	{
-	exc->process->heredoc_fd = reset_cursor_heredocfd(exc);
+		exc->process->heredoc_fd = reset_cursor_heredocfd(exc);
 		exc->process->reset_cursor_hd = true;
 	}
 	if (exc->process->infile != -1 && \
 exc->process->infile != exc->process->heredoc_fd)
-			close(exc->process->infile);
+		close(exc->process->infile);
 	exc->process->infile = exc->process->heredoc_fd;
 	execution(ast->left, exc);
 }
@@ -94,6 +94,5 @@ int	reset_cursor_heredocfd(t_exc *exc)
 		exc->exit_code = PERMISSION_DENIED;
 		return (-1);
 	}
-	fprintf(stderr, "FD OPEN: %d\n", exc->process->heredoc_fd);
 	return (exc->process->heredoc_fd);
 }

--- a/src/execution/exec/word/built_in/built_ins.c
+++ b/src/execution/exec/word/built_in/built_ins.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 18:15:50 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:06:27 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -63,8 +63,5 @@ void	built_ins(char **args, t_exc *exc)
 	else if (ft_strncmp(args[0], "exit", 5) == 0)
 		bi_exit(args, exc);
 	else
-	{
-		// fprintf(stderr, "args is empty\n");
 		return ;
-	}
 }

--- a/src/execution/exec/word/built_in/built_ins.c
+++ b/src/execution/exec/word/built_in/built_ins.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/15 18:15:50 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 13:45:31 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,8 +48,6 @@ void	exec_builtin(t_ast *ast, t_exc *exc)
 // for 
 void	built_ins(char **args, t_exc *exc)
 {
-	// if (!args[0])
-	// 	return ;
 	if (ft_strncmp(args[0], "echo", 5) == 0)
 		bi_echo(args, exc);
 	else if (ft_strncmp(args[0], "cd", 3) == 0)
@@ -66,7 +64,7 @@ void	built_ins(char **args, t_exc *exc)
 		bi_exit(args, exc);
 	else
 	{
-		fprintf(stderr, "args is empty\n");
+		// fprintf(stderr, "args is empty\n");
 		return ;
 	}
 }

--- a/src/execution/exec/word/command/access_and_execve.c
+++ b/src/execution/exec/word/command/access_and_execve.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 11:45:43 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 17:14:24 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:06:37 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,7 +25,6 @@ void	access_and_execve(t_exc *exc, t_ast *ast)
 
 	args = ast->token->basin_buff;
 	reset_signals_child();
-	// fprintf(stderr, "%s\n", args[0]);
 	if (!args || !args[0] || !args[0][0])
 		exit_access_and_execve(exc);
 	if (!ft_strncmp(args[0], "./", 2))
@@ -35,10 +34,8 @@ void	access_and_execve(t_exc *exc, t_ast *ast)
 	else
 		pathname = access_path(exc, args);
 	pathname_error_handling(exc, pathname, args);
-	// fprintf(stderr, "exit_code current in access_execeve betul22222 b4 execve = %d with command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
 	execve(pathname, args, exc->exec->envp_array);
 	free(pathname);
-	fprintf(stderr, "exit_code current in access_execveafter execve after exit = %d with command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
 	exit_access_and_execve(exc);
 }
 

--- a/src/execution/exec/word/command/access_and_execve.c
+++ b/src/execution/exec/word/command/access_and_execve.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/24 11:45:43 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 12:17:38 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 17:14:24 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -25,6 +25,7 @@ void	access_and_execve(t_exc *exc, t_ast *ast)
 
 	args = ast->token->basin_buff;
 	reset_signals_child();
+	// fprintf(stderr, "%s\n", args[0]);
 	if (!args || !args[0] || !args[0][0])
 		exit_access_and_execve(exc);
 	if (!ft_strncmp(args[0], "./", 2))
@@ -34,8 +35,10 @@ void	access_and_execve(t_exc *exc, t_ast *ast)
 	else
 		pathname = access_path(exc, args);
 	pathname_error_handling(exc, pathname, args);
+	// fprintf(stderr, "exit_code current in access_execeve betul22222 b4 execve = %d with command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
 	execve(pathname, args, exc->exec->envp_array);
 	free(pathname);
+	fprintf(stderr, "exit_code current in access_execveafter execve after exit = %d with command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
 	exit_access_and_execve(exc);
 }
 

--- a/src/execution/exec/word/command/exec_word.c
+++ b/src/execution/exec/word/command/exec_word.c
@@ -6,20 +6,21 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:07:12 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 13:45:31 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 17:15:47 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execution.h"
 
 void		exec_word(t_ast *ast, t_exc *exc);
-static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc);
+static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc, t_ast *ast);
 
 void	exec_word(t_ast *ast, t_exc *exc)
 {
 	pid_t	pid;
 	int		exit_status;
 
+	// fprintf(stderr, "exit_code current in exec_word b4 execve = %d\n", exc->exit_code);
 	exit_status = 0;
 	if (is_bi(ast->token->basin_buff) == 1)
 		exec_builtin(ast, exc);
@@ -39,7 +40,7 @@ void	exec_word(t_ast *ast, t_exc *exc)
 			access_and_execve(exc, ast);
 		}
 		close_infile_outfile_parent(exc);
-		waiting_exec_word(pid, exit_status, exc);
+		waiting_exec_word(pid, exit_status, exc, ast);
 		reset_stdin_stdout(exc);
 	}
 }
@@ -57,14 +58,18 @@ void	exec_word(t_ast *ast, t_exc *exc)
 // ( == 0) ---> false
 // ( != 0) ---> true
 // we need WIFSIGNALED coz we dont have signal_handler function (SIG_DFL)
-static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc)
+static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc, t_ast *ast)
 {
 	waitpid(pid, &exit_status, 0);
 	if (WIFEXITED(exit_status) != 0)
+	{
 		exc->exit_code = WEXITSTATUS(exit_status);
+		fprintf(stderr, "exit_code current in waiting_exec_word in WIFEXITED= %d, command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
+	}
 	else if (WIFSIGNALED(exit_status) != 0)
 	{
 		exc->exit_code = 128 + WTERMSIG(exit_status);
+		// fprintf(stderr, "exit_code current in waiting_exec_word in WIFSIGNALED= %d\n", exc->exit_code);
 		if (WTERMSIG(exit_status) == SIGINT)
 			write(1, "\n", 1);
 	}

--- a/src/execution/exec/word/command/exec_word.c
+++ b/src/execution/exec/word/command/exec_word.c
@@ -6,28 +6,26 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:07:12 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 11:30:44 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:35:20 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "execution.h"
 
 void		exec_word(t_ast *ast, t_exc *exc);
-static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc, t_ast *ast);
+static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc);
 
 void	exec_word(t_ast *ast, t_exc *exc)
 {
 	pid_t	pid;
 	int		exit_status;
 
-	// fprintf(stderr, "exit_code current in exec_word b4 execve = %d\n", exc->exit_code);
 	exit_status = 0;
 	if (is_bi(ast->token->basin_buff) == 1)
 		exec_builtin(ast, exc);
 	else
 	{
 		signal(SIGINT, SIG_IGN);
-		signal(EOF, SIG_IGN);
 		pid = fork();
 		dupping_stdin_stdout(exc);
 		if (pid < 0)
@@ -41,7 +39,7 @@ void	exec_word(t_ast *ast, t_exc *exc)
 			access_and_execve(exc, ast);
 		}
 		close_infile_outfile_parent(exc);
-		waiting_exec_word(pid, exit_status, exc, ast);
+		waiting_exec_word(pid, exit_status, exc);
 		reset_stdin_stdout(exc);
 	}
 }
@@ -58,19 +56,16 @@ void	exec_word(t_ast *ast, t_exc *exc)
 //	= what signal killed the child 
 // ( == 0) ---> false
 // ( != 0) ---> true
-// we need WIFSIGNALED coz we dont have signal_handler function (SIG_DFL / SIG_IGN)
-static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc, t_ast *ast)
+// we need WIFSIGNALED coz we dont have signal_handler function 
+// like (SIG_DFL / SIG_IGN)
+static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc)
 {
 	waitpid(pid, &exit_status, 0);
 	if (WIFEXITED(exit_status) != 0)
-	{
 		exc->exit_code = WEXITSTATUS(exit_status);
-		fprintf(stderr, "exit_code current in waiting_exec_word in WIFEXITED= %d, command: %s\n", exc->exit_code, ast->token->basin_buff[0]);
-	}
 	else if (WIFSIGNALED(exit_status) != 0)
 	{
 		exc->exit_code = 128 + WTERMSIG(exit_status);
-		// fprintf(stderr, "exit_code current in waiting_exec_word in WIFSIGNALED= %d\n", exc->exit_code);
 		if (WTERMSIG(exit_status) == SIGINT)
 			write(1, "\n", 1);
 	}

--- a/src/execution/exec/word/command/exec_word.c
+++ b/src/execution/exec/word/command/exec_word.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/17 10:07:12 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 17:15:47 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 11:30:44 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -27,6 +27,7 @@ void	exec_word(t_ast *ast, t_exc *exc)
 	else
 	{
 		signal(SIGINT, SIG_IGN);
+		signal(EOF, SIG_IGN);
 		pid = fork();
 		dupping_stdin_stdout(exc);
 		if (pid < 0)
@@ -57,7 +58,7 @@ void	exec_word(t_ast *ast, t_exc *exc)
 //	= what signal killed the child 
 // ( == 0) ---> false
 // ( != 0) ---> true
-// we need WIFSIGNALED coz we dont have signal_handler function (SIG_DFL)
+// we need WIFSIGNALED coz we dont have signal_handler function (SIG_DFL / SIG_IGN)
 static void	waiting_exec_word(pid_t pid, int exit_status, t_exc *exc, t_ast *ast)
 {
 	waitpid(pid, &exit_status, 0);

--- a/src/execution/exec/word/command/word_utils.c
+++ b/src/execution/exec/word/command/word_utils.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 20:33:21 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 10:56:56 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,13 +22,19 @@ void	dup2_close_infile_outfile(t_exc *exc)
 {
 	if (exc->process->infile != -1)
 	{
-		if (exc->process->infile == exc->process->heredoc_fd)
-			// fprintf(stderr, "heredoc_fd bring dup2 !!\n");
 		dup2(exc->process->infile, STDIN_FILENO);
+		if (exc->process->infile == exc->process->heredoc_fd)
+		{
+			fprintf(stderr, "heredoc_fd being dup2 !!\n");
+			fprintf(stderr, "FD CLOSE: %d\n", exc->process->heredoc_fd);
+		}
 		close(exc->process->infile);
 		if (exc->process->heredoc_fd != -1 && \
 exc->process->infile != exc->process->heredoc_fd)
+		{
+			fprintf(stderr, "latest infile is not heredoc\n");
 			close(exc->process->heredoc_fd);
+		}
 	}
 	if (exc->process->outfile != -1)
 	{
@@ -42,6 +48,7 @@ void	close_infile_outfile_parent(t_exc *exc)
 	if (exc->process->infile != -1)
 	{
 		close(exc->process->infile);
+		fprintf(stderr, "FD CLOSE: %d\n", exc->process->heredoc_fd);
 		if (exc->process->heredoc_fd != -1 && \
 exc->process->infile != exc->process->heredoc_fd)
 			close(exc->process->heredoc_fd);

--- a/src/execution/exec/word/command/word_utils.c
+++ b/src/execution/exec/word/command/word_utils.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 20:33:21 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 13:45:31 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 16:51:37 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -22,6 +22,8 @@ void	dup2_close_infile_outfile(t_exc *exc)
 {
 	if (exc->process->infile != -1)
 	{
+		if (exc->process->infile == exc->process->heredoc_fd)
+			// fprintf(stderr, "heredoc_fd bring dup2 !!\n");
 		dup2(exc->process->infile, STDIN_FILENO);
 		close(exc->process->infile);
 		if (exc->process->heredoc_fd != -1 && \

--- a/src/execution/exec/word/command/word_utils.c
+++ b/src/execution/exec/word/command/word_utils.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/10 20:33:21 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 10:56:56 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:09:54 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -23,18 +23,10 @@ void	dup2_close_infile_outfile(t_exc *exc)
 	if (exc->process->infile != -1)
 	{
 		dup2(exc->process->infile, STDIN_FILENO);
-		if (exc->process->infile == exc->process->heredoc_fd)
-		{
-			fprintf(stderr, "heredoc_fd being dup2 !!\n");
-			fprintf(stderr, "FD CLOSE: %d\n", exc->process->heredoc_fd);
-		}
 		close(exc->process->infile);
 		if (exc->process->heredoc_fd != -1 && \
 exc->process->infile != exc->process->heredoc_fd)
-		{
-			fprintf(stderr, "latest infile is not heredoc\n");
 			close(exc->process->heredoc_fd);
-		}
 	}
 	if (exc->process->outfile != -1)
 	{
@@ -48,7 +40,6 @@ void	close_infile_outfile_parent(t_exc *exc)
 	if (exc->process->infile != -1)
 	{
 		close(exc->process->infile);
-		fprintf(stderr, "FD CLOSE: %d\n", exc->process->heredoc_fd);
 		if (exc->process->heredoc_fd != -1 && \
 exc->process->infile != exc->process->heredoc_fd)
 			close(exc->process->heredoc_fd);
@@ -64,5 +55,3 @@ void	reset_stdin_stdout(t_exc *exc)
 	dup2(exc->process->dupped_stdout, STDOUT_FILENO);
 	close(exc->process->dupped_stdout);
 }
-
-

--- a/src/execution/utils/init.c
+++ b/src/execution/utils/init.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/20 13:55:41 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 09:47:25 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:03:35 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -81,7 +81,6 @@ void	mallocing_heredoc(t_exc *exc)
 	exc->process->total_hd = total_heredocs(exc->data->token);
 	if (exc->process->total_hd > 0)
 	{
-		exc->process->heredoc_exists = true;
 		exc->process->limiters = malloc(sizeof(char *) * \
 (exc->process->total_hd + 1));
 		exc->process->limiters[exc->process->total_hd] = NULL;

--- a/src/execution/utils/reset_signal.c
+++ b/src/execution/utils/reset_signal.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 17:54:37 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 15:39:31 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 11:30:58 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -30,7 +30,7 @@ void	reset_signals_child(void)
 {
 	signal(SIGINT, SIG_DFL);
 	signal(SIGQUIT, SIG_IGN);
-	signal(EOF, SIG_IGN);
+	signal(EOF, SIG_DFL);
 }
 
 void	reset_before_readline(t_exc *exc)
@@ -51,6 +51,7 @@ void	reset_before_readline(t_exc *exc)
 	exc->process->heredoc_fd = -1;
 	exc->process->pipe_flag = false;
 	exc->process->dup_heredoc = false;
+	exc->process->reset_cursor_hd = false;
 	if (access("heredoc_fd", F_OK) == 0)
 		unlink("heredoc_fd");
 }

--- a/src/execution/utils/reset_signal.c
+++ b/src/execution/utils/reset_signal.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 17:54:37 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/25 11:30:58 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:35:30 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -42,15 +42,11 @@ void	reset_before_readline(t_exc *exc)
 	}
 	reset_signals();
 	if (exc->process->total_hd > 0)
-	{
 		exc->process->limiter_index = 0;
-		exc->process->heredoc_exists = false;
-	}
 	exc->process->infile = -1;
 	exc->process->outfile = -1;
 	exc->process->heredoc_fd = -1;
 	exc->process->pipe_flag = false;
-	exc->process->dup_heredoc = false;
 	exc->process->reset_cursor_hd = false;
 	if (access("heredoc_fd", F_OK) == 0)
 		unlink("heredoc_fd");

--- a/src/execution/utils/reset_signal.c
+++ b/src/execution/utils/reset_signal.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/07/04 17:54:37 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/24 13:44:38 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/24 15:39:31 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -50,6 +50,7 @@ void	reset_before_readline(t_exc *exc)
 	exc->process->outfile = -1;
 	exc->process->heredoc_fd = -1;
 	exc->process->pipe_flag = false;
+	exc->process->dup_heredoc = false;
 	if (access("heredoc_fd", F_OK) == 0)
 		unlink("heredoc_fd");
 }

--- a/src/execution/utils/signals.c
+++ b/src/execution/utils/signals.c
@@ -6,7 +6,7 @@
 /*   By: aimokhta <aimokhta@student.42kl.edu.my>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/05/27 11:40:59 by aimokhta          #+#    #+#             */
-/*   Updated: 2025/07/22 10:30:29 by aimokhta         ###   ########.fr       */
+/*   Updated: 2025/07/25 12:24:04 by aimokhta         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -37,7 +37,8 @@ void	handle_cntrl_d(int sig)
 {
 	(void)sig;
 	printf("exit\n");
-	exit(EXIT_SUCCESS);
+	g_signal = EXIT_SUCCESS;
+	exit(g_signal);
 }
 
 void	handle_cntrl_c_heredoc(int sig)

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -74,14 +74,11 @@ static void	int_main_loop(t_exc *exc)
 		mallocing_heredoc(exc);
 		combine_all_heredoc(data.root, exc);
 		printf("------------------\n");
-		// expand_tokens(data.token, exc);
+		expand_tokens(data.token, exc);
 		printf("------------------\n");
 		printf("exit_code before execution: %d\n", exc->exit_code);
-		if (!(exc->exit_code == 130 && exc->process->heredoc_exists == true))
-		{
-			// fprintf(stderr, "im entering ast_exec\n");
+		if (!(exc->exit_code == 130 && exc->process->total_hd > 0))
 			execution(data.root, exc);
-		}
 		reset_before_readline(exc);
 		free_before_readline(exc);
 		printf("exit_code before readline: %d\n", exc->exit_code);

--- a/src/minishell.c
+++ b/src/minishell.c
@@ -74,11 +74,14 @@ static void	int_main_loop(t_exc *exc)
 		mallocing_heredoc(exc);
 		combine_all_heredoc(data.root, exc);
 		printf("------------------\n");
-		expand_tokens(data.token, exc);
+		// expand_tokens(data.token, exc);
 		printf("------------------\n");
 		printf("exit_code before execution: %d\n", exc->exit_code);
 		if (!(exc->exit_code == 130 && exc->process->heredoc_exists == true))
+		{
+			// fprintf(stderr, "im entering ast_exec\n");
 			execution(data.root, exc);
+		}
 		reset_before_readline(exc);
 		free_before_readline(exc);
 		printf("exit_code before readline: %d\n", exc->exit_code);


### PR DESCRIPTION
- properly open and close heredoc
- accept the mentioning of limiters itself or replace it with EOF instead . for example: there are 3 heredocs, we need to do EOF 3 times to exit the heredoc process/ or replace any of the limiters in sequence with EOF